### PR TITLE
Add ClawBench benchmark

### DIFF
--- a/data/clawbench.yml
+++ b/data/clawbench.yml
@@ -1,0 +1,9 @@
+name: ClawBench
+slug: clawbench
+url: https://github.com/TIGER-AI-Lab/ClawBench
+oneliner: Live-web benchmark for evaluating browser and computer-use agents.
+description: ClawBench evaluates browser and computer-use agents on 283 tasks across 163 live websites with request interception and execution evidence.
+main_category: open-source
+categories: []
+date_added: 2026-07-28
+date_modified: 2026-07-28


### PR DESCRIPTION
ClawBench is a maintained open-source benchmark for browser and computer-use agents, so it fits this agent-resource list. The entry is a concise factual record with the canonical repository and current scope (283 tasks across 163 live websites, request interception, and execution evidence).\n\nDisclosure: I help maintain ClawBench.