### PR TITLE
Add Orkas to open-source projects

### DIFF
--- a/data/orkas.yml
+++ b/data/orkas.yml
@@ -1,0 +1,10 @@
+name: Orkas
+slug: orkas
+url: https://github.com/Orkas-AI/Orkas
+position: ordinary
+oneliner: Local-first desktop workspace for commanding a team of specialized AI agents.
+description: Open-source desktop client where a Commander coordinates specialized agents in parallel or in series through one conversation, with bring-your-own model providers.
+main_category: open-source
+categories: []
+date_added: 2026-08-03
+date_modified: 2026-08-03


### PR DESCRIPTION
Adds Orkas to the generated catalog as an open-source project.

The new `data/orkas.yml` record includes all required fields, uses the canonical repository URL, and follows the filename/slug and category rules.

Validation:
- Parsed the new file successfully as YAML.
- Confirmed the canonical URL is reachable.
- Ran `git diff --check`.

The generated README is intentionally unchanged, per the contribution guide.