### PR TITLE
Add ebase

### DIFF
--- a/data/ebase.yml
+++ b/data/ebase.yml
@@ -1,0 +1,8 @@
+name: ebase
+slug: ebase
+url: https://github.com/embeddingvc/ebase
+oneliner: Open-source LinkedIn recruiting outreach for Claude Code.
+description: MCP server driving your own signed-in Chrome for connection requests, DMs, and profile research, with enforced daily activity limits and persistent pipeline state.
+main_category: open-source
+categories: []
+date_added: 2026-08-08


### PR DESCRIPTION
Adds **ebase** (https://github.com/embeddingvc/ebase) as a new `data/ebase.yml` entry (open-source category), per CONTRIBUTING.md.

ebase is an open-source (MIT) LinkedIn recruiting outreach tool built as a Claude Code MCP server — connection requests, DMs, and profile research from your own signed-in Chrome, with enforced daily activity limits and persistent pipeline state.

**Disclosure:** I'm a contributor/maintainer of ebase, submitting this listing per the repo's contribution guidelines.