### PR TITLE
Add Atomic Agent

### DIFF
--- a/data/atomic-agent.yml
+++ b/data/atomic-agent.yml
@@ -1,0 +1,10 @@
+name: Atomic Agent
+slug: atomic-agent
+url: https://github.com/AtomicBot-ai/atomic-agent
+position: ordinary
+oneliner: Local-first CLI and TUI coding agent for open-weight models.
+description: MIT-licensed CLI and TUI agentic coding assistant that runs open-weight models entirely on your machine through a llama.cpp fork, with no account or API key required. Ships 56 built-in tools (browser, filesystem, git, memory, vision), MCP support, a five-layer local memory system, and a React and ink TUI. Runs on macOS, Linux and Windows.
+main_category: open-source
+categories: []
+date_added: 2026-08-13
+date_modified: 2026-08-13


### PR DESCRIPTION
Hi! I'm the CPO of Atomic Agent. Thanks for keeping this list, it's one of the cleaner AI agent lists out there and our team would be thrilled to be on it.

Adds `data/atomic-agent.yml` under `main_category: open-source`. I followed CONTRIBUTING and edited the YAML source only, so I left the generated `README.md` untouched for the compiler to regenerate.

**What it is**

Atomic Agent is a local-first CLI and TUI coding assistant. It runs open-weight models entirely on your machine through a llama.cpp fork, so no account or API key is needed to install or run it.

- 56 built-in tools (browser, filesystem, git, memory, vision)
- MCP (Model Context Protocol) support
- Five-layer local memory system
- TUI built on React and ink
- macOS, Linux and Windows
- MIT licensed, ~2k stars, actively developed

Install: `curl -fsSL https://atomicagent.io/install | sh`

**Links**

- Repo: https://github.com/AtomicBot-ai/atomic-agent
- Site: https://atomicagent.io
- Docs: https://atomicagent.io/docs
- X: https://x.com/atomicagent_io
- Discord: https://discord.gg/Us7qXtDGw

**Checklist**

- Alphabetical order maintained (the compiler places it between AIlice and AutoGPT)
- `slug` matches the filename
- Required fields present: name, slug, url, oneliner, main_category
- Verified with the `alternbits/opendata` compiler locally, it validates and produces the expected row

One note in the spirit of full disclosure: the repo is about 4 months old. It's active and maintained by the AtomicBot-ai organization, which ships several established projects. Happy to adjust the wording, the oneliner, or the position value if you'd prefer something different.
