### PR TITLE
Add Agent Coordinator

### DIFF
--- a/data/agent-coordinator.yml
+++ b/data/agent-coordinator.yml
@@ -1,0 +1,10 @@
+name: Agent Coordinator
+slug: agent-coordinator
+url: https://github.com/alanhoff/agent-coordinator
+position: ordinary
+oneliner: Codex skill that runs bounded work graphs, records revisioned local state, reconciles uncertain work before retry, and reruns authored closeout checks.
+description: Per-user Codex skill for dependency-aware tasks. The parent task owns graph changes and integration; scoped nodes can run inline or through optional specialists, uncertain operations are reconciled before retry, and authored checks run again at closeout.
+main_category: open-source
+categories: []
+date_added: 2026-09-01
+date_modified: 2026-09-01


### PR DESCRIPTION
## Summary

- Add `data/agent-coordinator.yml` under the existing `open-source` category.
- Keep the generated `README.md` untouched, as required by this repository's contribution guide.

## Fit

Agent Coordinator is a per-user Codex skill for running complex work from a bounded dependency graph. The parent task owns graph changes and integration, while specialist delegation is optional. The skill records revisioned local state, reconciles uncertain work before retry, and reruns authored checks at closeout.

It is an open-source project for agent workflow execution, not a standalone agent service or a generic agent SDK.

## Validation

- Confirmed the slug matches `data/agent-coordinator.yml` and every required YAML field is present.
- Used the canonical public repository and the existing `open-source` category.
- Searched the README, data files, issues, and pull requests for the project name and canonical URL; no duplicate was found.
- Checked the source at `fb3d64688a9e1b7c02a114a14faac1219ec10f51`; its CI matrix passed.
- Ran `git diff --check` and confirmed this branch changes only the YAML source file. The destination's OpenData action will validate and compile it in CI.

I maintain Agent Coordinator. Codex helped inspect the live schema, draft the record, and run the checks above.
