### PR TITLE
Add sofagent (commit-time audit harness) to Open-source Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A curated list of AI agents, categorized into open-source projects and closed-so
 - [Giselle](https://github.com/giselles-ai/giselle) - AI for Agentic Workflows. Human-AI Collaboration. Open Source.
 - [GPTSwarm](https://gptswarm.org/) - Optimizable graph-based AI agents.
 - [Upsonic](https://github.com/Upsonic/Upsonic) - Reliable agent framework that support MCP.
+- [sofagent](https://github.com/KongFangXun/sofagent) - Commit-time audit harness for AI coding agents: 24 git-diff rules, HMAC-chained local audit logs, snapshot rollback.
 
 ---
 


### PR DESCRIPTION
Adds [KongFangXun/sofagent](https://github.com/KongFangXun/sofagent) to the **Open-source Projects** list, right after Upsonic.

**Disclosure: this is a self-submission.** I am the author and maintainer of sofagent.

While most entries in this list cover agent *frameworks*, sofagent complements them from the governance side: it is a commit-time audit harness that scans git diffs of AI coding agents (Claude Code, Codex, Cursor) with 24 rules — blocking secret leaks, out-of-scope file edits, and commit-message prompt injection before the commit lands — and writes an HMAC-chained, tamper-evident audit log with snapshot rollback. MIT-licensed, fully local, no paid backend.

Already listed in [awesome-dsh-plugin](https://github.com/awesome-dsh-plugin/awesome-dsh-plugin) (security category) and [punkpeye/awesome-mcp-servers](https://github.com/punkpeye/awesome-mcp-servers/pull/13312) (in review) — cross-references for trust.

Single-line change to README.md only.
